### PR TITLE
Add plugin-based voice assistant skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Nova AI Assistant
+
+Pequeño asistente de voz que se activa mediante una palabra clave y ejecuta
+acciones mediante un sistema de _plugins_. Está pensado como base para un
+proyecto estilo **J.A.R.V.I.S.**
+
+## Instalación
+
+1. Instala las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Asegúrate de que tu sistema dispone de un micrófono accesible por Python.
+
+## Configuración
+
+El archivo `src/config.json` define la palabra de activación y los plugins a
+cargar.
+
+```json
+{
+  "activation_word": "NOVA",
+  "plugins": ["open_browser", "system_control", "volume_control"]
+}
+```
+
+Puedes modificar `activation_word` y añadir tus propios plugins.
+
+## Uso
+
+Ejecuta el asistente con:
+
+```bash
+python src/main.py
+```
+
+El programa permanece escuchando y, cuando se detecta la palabra de activación,
+intenta interpretar la orden con alguno de los plugins disponibles.
+
+### Comandos soportados
+
+- **Abrir navegador**
+  - "NOVA abre Chrome"
+  - "NOVA quiero que abras el navegador"
+- **Control del sistema**
+  - "NOVA apaga el ordenador"
+  - "NOVA suspende el equipo"
+- **Control de volumen**
+  - "NOVA sube el volumen"
+  - "NOVA baja el volumen"
+
+## Extensión mediante plugins
+
+Cada plugin se ubica en `src/plugins/` y hereda de `BasePlugin`. Debe implementar
+los métodos `can_handle` y `handle`.
+
+Ejemplo mínimo:
+
+```python
+from plugins import BasePlugin
+
+class Plugin(BasePlugin):
+    def can_handle(self, text: str) -> bool:
+        return "hola" in text
+
+    def handle(self, text: str) -> str:
+        print("Hola mundo")
+        return "Saludando"
+```
+
+Añade el nombre del módulo a la lista `plugins` de `config.json` para activarlo.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+SpeechRecognition

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for nova-ai-assistant

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,8 @@
+{
+  "activation_word": "NOVA",
+  "plugins": [
+    "open_browser",
+    "system_control",
+    "volume_control"
+  ]
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,46 @@
+"""Entry point for the Nova voice assistant."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import speech_recognition as sr
+
+from plugins import load_plugins
+
+
+def listen_loop(activation_word: str, plugin_names):
+    """Continuously listen for commands starting with the activation word."""
+    recognizer = sr.Recognizer()
+    plugins = load_plugins(plugin_names)
+    activation_word = activation_word.lower()
+
+    with sr.Microphone() as source:
+        print(f"Escuchando. Di '{activation_word}' para activar.")
+        while True:
+            audio = recognizer.listen(source)
+            try:
+                text = recognizer.recognize_google(audio, language="es-ES").lower()
+                if activation_word in text:
+                    command = text.replace(activation_word, "", 1).strip()
+                    print(f"Comando detectado: {command}")
+                    for plugin in plugins:
+                        if plugin.can_handle(command):
+                            response = plugin.handle(command)
+                            print(response)
+                            break
+                    else:
+                        print("No se encontró un plugin para esa orden")
+            except sr.UnknownValueError:
+                continue
+
+
 def main():
-    print("Hello, World!")
-    print("This is a simple Python script.")
-    print("Let's add some more functionality.")
-    print("Here's a new feature!")
-    print("And another one!")
+    config_path = Path(__file__).resolve().parent / "config.json"
+    with config_path.open(encoding="utf-8") as f:
+        config = json.load(f)
+    listen_loop(config.get("activation_word", "NOVA"), config.get("plugins", []))
+
 
 if __name__ == "__main__":
     main()

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,27 @@
+"""Plugin infrastructure for Nova assistant."""
+from __future__ import annotations
+
+import importlib
+from typing import List, Type
+
+
+class BasePlugin:
+    """Base class for all plugins."""
+
+    def can_handle(self, text: str) -> bool:
+        """Return True if plugin can handle the provided command."""
+        raise NotImplementedError
+
+    def handle(self, text: str) -> str:
+        """Execute the plugin action and return a human readable result."""
+        raise NotImplementedError
+
+
+def load_plugins(plugin_names: List[str]) -> List[BasePlugin]:
+    """Dynamically import and instantiate plugin classes."""
+    plugins: List[BasePlugin] = []
+    for name in plugin_names:
+        module = importlib.import_module(f"plugins.{name}")
+        plugin_cls: Type[BasePlugin] = getattr(module, "Plugin")
+        plugins.append(plugin_cls())
+    return plugins

--- a/src/plugins/open_browser.py
+++ b/src/plugins/open_browser.py
@@ -1,0 +1,20 @@
+"""Plugin to open a web browser."""
+from __future__ import annotations
+
+import webbrowser
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Open a web browser when the user requests it."""
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        keywords = ["abre", "abrir"]
+        targets = ["chrome", "navegador", "browser"]
+        return any(k in text for k in keywords) and any(t in text for t in targets)
+
+    def handle(self, text: str) -> str:
+        webbrowser.open("https://www.google.com")
+        return "Abriendo navegador"

--- a/src/plugins/system_control.py
+++ b/src/plugins/system_control.py
@@ -1,0 +1,40 @@
+"""Plugin to manage basic system power commands."""
+from __future__ import annotations
+
+import subprocess
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Handle power and session control commands."""
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        keywords = [
+            "apaga",
+            "apagar",
+            "suspende",
+            "suspender",
+            "hiberna",
+            "hibernar",
+            "reinicia",
+            "reiniciar",
+        ]
+        return any(k in text for k in keywords)
+
+    def handle(self, text: str) -> str:
+        text = text.lower()
+        if "apaga" in text or "apagar" in text:
+            subprocess.run(["shutdown", "now"], check=False)
+            return "Apagando el sistema"
+        if "suspende" in text or "suspender" in text:
+            subprocess.run(["systemctl", "suspend"], check=False)
+            return "Suspendiendo el sistema"
+        if "hiberna" in text or "hibernar" in text:
+            subprocess.run(["systemctl", "hibernate"], check=False)
+            return "Hibernando el sistema"
+        if "reinicia" in text or "reiniciar" in text:
+            subprocess.run(["reboot"], check=False)
+            return "Reiniciando el sistema"
+        return "No se reconoció la orden del sistema"

--- a/src/plugins/volume_control.py
+++ b/src/plugins/volume_control.py
@@ -1,0 +1,30 @@
+"""Plugin to control system volume."""
+from __future__ import annotations
+
+import subprocess
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Adjust the system volume using pactl."""
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        return "volumen" in text or "volume" in text
+
+    def handle(self, text: str) -> str:
+        text = text.lower()
+        if any(word in text for word in ["sube", "subir", "aumenta", "aumentar"]):
+            subprocess.run(["pactl", "set-sink-volume", "@DEFAULT_SINK@", "+5%"], check=False)
+            return "Subiendo volumen"
+        if any(word in text for word in ["baja", "bajar", "reduce", "reducir"]):
+            subprocess.run(["pactl", "set-sink-volume", "@DEFAULT_SINK@", "-5%"], check=False)
+            return "Bajando volumen"
+        if any(word in text for word in ["mute", "silencia", "silenciar"]):
+            subprocess.run(["pactl", "set-sink-mute", "@DEFAULT_SINK@", "1"], check=False)
+            return "Silenciando volumen"
+        if any(word in text for word in ["unmute", "sonido", "activa", "activar"]):
+            subprocess.run(["pactl", "set-sink-mute", "@DEFAULT_SINK@", "0"], check=False)
+            return "Activando volumen"
+        return "No se reconoció la orden de volumen"


### PR DESCRIPTION
## Summary
- implement continuous voice assistant activated by a configurable keyword
- add plugin infrastructure with browser, system control and volume plugins
- document usage and configuration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b174edf7f48333b40f68f037f3345f