### PR TITLE
Add media control plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ configurar un fichero de memoria persistente y los escenarios disponibles.
     "open_browser",
     "system_control",
     "volume_control",
+    "media_control",
     "scenario_control"
   ]
 }
@@ -68,6 +69,11 @@ Los escenarios permiten ejecutar varias acciones predefinidas, por ejemplo:
 - **Control de volumen**
   - "NOVA sube el volumen"
   - "NOVA baja el volumen"
+- **Control multimedia**
+  - "NOVA reproduce"
+  - "NOVA pausa la música"
+  - "NOVA siguiente canción"
+  - "NOVA canción anterior"
 
 ## Extensión mediante plugins
 

--- a/src/nova/config.json
+++ b/src/nova/config.json
@@ -9,6 +9,7 @@
     "open_browser",
     "system_control",
     "volume_control",
+    "media_control",
     "scenario_control"
   ]
 }

--- a/src/nova/plugins/media_control.py
+++ b/src/nova/plugins/media_control.py
@@ -1,0 +1,34 @@
+"""Plugin to control media playback using playerctl."""
+from __future__ import annotations
+
+import subprocess
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Control media playback with playerctl."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        keywords = ["reproduce", "pausa", "siguiente", "anterior"]
+        return any(k in text for k in keywords)
+
+    def handle(self, text: str) -> str:
+        text = text.lower()
+        if "reproduce" in text:
+            subprocess.run(["playerctl", "play"], check=False)
+            return "Reproduciendo"
+        if "pausa" in text:
+            subprocess.run(["playerctl", "pause"], check=False)
+            return "Pausando"
+        if "siguiente" in text:
+            subprocess.run(["playerctl", "next"], check=False)
+            return "Siguiente pista"
+        if "anterior" in text:
+            subprocess.run(["playerctl", "previous"], check=False)
+            return "Pista anterior"
+        return "No se reconoció la orden multimedia"


### PR DESCRIPTION
## Summary
- add media control plugin using playerctl
- register plugin in configuration
- document media commands in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b18c06df3c83338e7ad012adce3832