### PR TITLE
Add timer alarm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ configurar un fichero de memoria persistente y los escenarios disponibles.
     "volume_control",
     "media_control",
     "scenario_control",
-    "brightness_control"
+    "brightness_control",
+    "timer_alarm"
   ]
 }
 ```
@@ -80,6 +81,9 @@ Los escenarios permiten ejecutar varias acciones predefinidas, por ejemplo:
   - "NOVA pausa la música"
   - "NOVA siguiente canción"
   - "NOVA canción anterior"
+- **Temporizadores y alarmas**
+  - "NOVA temporizador de 5 minutos"
+  - "NOVA pon una alarma de 10 segundos"
 
 ## Extensión mediante plugins
 

--- a/src/nova/config.json
+++ b/src/nova/config.json
@@ -11,6 +11,7 @@
     "volume_control",
     "media_control",
     "scenario_control",
-    "brightness_control"
+    "brightness_control",
+    "timer_alarm"
   ]
 }

--- a/src/nova/plugins/timer_alarm.py
+++ b/src/nova/plugins/timer_alarm.py
@@ -1,0 +1,37 @@
+"""Plugin to set timers or alarms."""
+from __future__ import annotations
+
+import re
+import threading
+
+from . import BasePlugin
+
+
+def _alarm_action(message: str) -> None:
+    """Print a message and emit a beep when the timer finishes."""
+    print("\a" + message)
+
+
+class Plugin(BasePlugin):
+    """Launch a timer or alarm using ``threading.Timer``."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        return "temporizador" in text or "alarma" in text
+
+    def handle(self, text: str) -> str:
+        text = text.lower()
+        match = re.search(r"(\d+)\s*(segundo|segundos|minuto|minutos)", text)
+        if not match:
+            return "No se especificó un tiempo para el temporizador"
+        amount = int(match.group(1))
+        unit = match.group(2)
+        seconds = amount * 60 if "minuto" in unit else amount
+
+        timer = threading.Timer(seconds, _alarm_action, args=("¡Tiempo cumplido!",))
+        timer.daemon = True
+        timer.start()
+        return f"Temporizador iniciado por {amount} {unit}"


### PR DESCRIPTION
## Summary
- add `timer_alarm` plugin using `threading.Timer`
- document and enable `timer_alarm` in config and README

## Testing
- `python -m py_compile src/nova/plugins/timer_alarm.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b18f0b4db083338369a0da241ecd11