### PR TITLE
feat: add note taking plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ configurar un fichero de memoria persistente y los escenarios disponibles.
     "media_control",
     "scenario_control",
     "brightness_control",
-    "timer_alarm"
+    "timer_alarm",
+    "note_taker"
   ]
 }
 ```
@@ -84,6 +85,11 @@ Los escenarios permiten ejecutar varias acciones predefinidas, por ejemplo:
 - **Temporizadores y alarmas**
   - "NOVA temporizador de 5 minutos"
   - "NOVA pon una alarma de 10 segundos"
+- **Toma de notas**
+  - "NOVA toma nota de comprar leche"
+  - "NOVA anota llamar al doctor"
+
+Las notas se almacenan en `notes.txt` en la raíz del proyecto.
 
 ## Extensión mediante plugins
 

--- a/src/nova/config.json
+++ b/src/nova/config.json
@@ -12,6 +12,7 @@
     "media_control",
     "scenario_control",
     "brightness_control",
-    "timer_alarm"
+    "timer_alarm",
+    "note_taker"
   ]
 }

--- a/src/nova/plugins/note_taker.py
+++ b/src/nova/plugins/note_taker.py
@@ -1,0 +1,35 @@
+"""Plugin to take textual notes and append them to a local file."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Append dictated text to ``notes.txt`` in the project root."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+        # ``notes.txt`` lives at the repository root
+        self.notes_path = Path(__file__).resolve().parents[3] / "notes.txt"
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        return "toma nota" in text or "anota" in text
+
+    def handle(self, text: str) -> str:
+        text = text.lower()
+        note = ""
+        if "toma nota" in text:
+            note = text.split("toma nota", 1)[1].strip()
+        elif "anota" in text:
+            note = text.split("anota", 1)[1].strip()
+        else:
+            note = text
+        if not note:
+            return "No se proporcionó contenido para anotar"
+        self.notes_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.notes_path.open("a", encoding="utf-8") as f:
+            f.write(note + "\n")
+        return "Nota guardada"


### PR DESCRIPTION
## Summary
- add note_taker plugin that appends dictated text to notes.txt
- document location and usage of notes file
- enable note_taker via config.json

## Testing
- `python -m py_compile src/nova/plugins/note_taker.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b19060355083338aa9390fb7dd628f