### PR TITLE
feat: add calculator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ configurar un fichero de memoria persistente y los escenarios disponibles.
     "scenario_control",
     "brightness_control",
     "timer_alarm",
-    "note_taker"
+    "note_taker",
+    "calculator"
   ]
 }
 ```
@@ -88,6 +89,9 @@ Los escenarios permiten ejecutar varias acciones predefinidas, por ejemplo:
 - **Toma de notas**
   - "NOVA toma nota de comprar leche"
   - "NOVA anota llamar al doctor"
+- **Calculadora**
+  - "NOVA cuánto es 2 más 2"
+  - "NOVA calcula 5 por 7"
 
 Las notas se almacenan en `notes.txt` en la raíz del proyecto.
 

--- a/src/nova/config.json
+++ b/src/nova/config.json
@@ -13,6 +13,7 @@
     "scenario_control",
     "brightness_control",
     "timer_alarm",
-    "note_taker"
+    "note_taker",
+    "calculator"
   ]
 }

--- a/src/nova/plugins/calculator.py
+++ b/src/nova/plugins/calculator.py
@@ -1,0 +1,66 @@
+"""Plugin to evaluate arithmetic expressions safely."""
+from __future__ import annotations
+
+import ast
+import operator
+import re
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Evaluate simple arithmetic expressions using AST for safety."""
+
+    def can_handle(self, text: str) -> bool:
+        text = text.lower()
+        ops = ["más", "mas", "menos", "por", "entre"]
+        return any(op in text for op in ops) and bool(re.search(r"\d", text))
+
+    def handle(self, text: str) -> str:
+        text = text.lower()
+        replacements = {
+            "más": "+",
+            "mas": "+",
+            "menos": "-",
+            "por": "*",
+            "entre": "/",
+        }
+        for word, symbol in replacements.items():
+            text = text.replace(word, symbol)
+        expr = "".join(ch for ch in text if ch in "0123456789+-*/.()")
+        if not expr:
+            return "No se encontró una expresión válida"
+        try:
+            result = self._safe_eval(expr)
+        except Exception:
+            return "Error al evaluar la expresión"
+        if isinstance(result, float) and result.is_integer():
+            result = int(result)
+        return str(result)
+
+    def _safe_eval(self, expression: str) -> float:
+        node = ast.parse(expression, mode="eval")
+        return self._eval_node(node.body)
+
+    def _eval_node(self, node: ast.AST) -> float:
+        if isinstance(node, ast.BinOp):
+            left = self._eval_node(node.left)
+            right = self._eval_node(node.right)
+            operators = {
+                ast.Add: operator.add,
+                ast.Sub: operator.sub,
+                ast.Mult: operator.mul,
+                ast.Div: operator.truediv,
+            }
+            op_type = type(node.op)
+            if op_type in operators:
+                return operators[op_type](left, right)
+            raise ValueError("Operador no permitido")
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            operand = self._eval_node(node.operand)
+            return operand if isinstance(node.op, ast.UAdd) else -operand
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.Num):  # pragma: no cover
+            return node.n
+        raise ValueError("Expresión no permitida")


### PR DESCRIPTION
## Summary
- add calculator plugin for safe arithmetic evaluation
- enable calculator in config
- document calculator usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b194d1f9a08333b0515fceaf232803