### PR TITLE
Handle direct execution of Nova modules

### DIFF
--- a/src/nova/__main__.py
+++ b/src/nova/__main__.py
@@ -1,7 +1,10 @@
 """Command line interface for the Nova assistant."""
 from __future__ import annotations
 
-from .main import main
+try:
+    from .main import main
+except ImportError:  # pragma: no cover
+    from main import main
 
 
 def run() -> None:

--- a/src/nova/main.py
+++ b/src/nova/main.py
@@ -8,7 +8,10 @@ from pathlib import Path
 import keyboard
 import speech_recognition as sr
 
-from .plugins import load_plugins
+try:
+    from .plugins import load_plugins
+except ImportError:  # pragma: no cover
+    from plugins import load_plugins
 
 
 class Memory:


### PR DESCRIPTION
## Summary
- Support running `main.py` and `__main__.py` directly by falling back to absolute imports when package context is missing

## Testing
- `python -m py_compile src/nova/main.py src/nova/__main__.py`
- `python src/nova/main.py` *(fails: No module named 'keyboard')*

------
https://chatgpt.com/codex/tasks/task_b_68b19ca1b3f48333b78f2bdd0f7a7d63